### PR TITLE
待機部屋の修正

### DIFF
--- a/src/app/tetris/components/PasscodeEntry.tsx
+++ b/src/app/tetris/components/PasscodeEntry.tsx
@@ -1,69 +1,140 @@
 'use client';
 
 import { useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { apiRequest } from '@/lib/api';
 
 interface PasscodeEntryProps {
-  onPasscodeSubmit: (passcode: string) => void;
+  onRoomReady: (passcode: string, isHost: boolean) => void;
 }
 
-export default function PasscodeEntry({ onPasscodeSubmit }: PasscodeEntryProps) {
-  const [passcode, setPasscode] = useState('');
+export default function PasscodeEntry({ onRoomReady }: PasscodeEntryProps) {
+  const [joinCode, setJoinCode] = useState('');
   const [error, setError] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [isJoining, setIsJoining] = useState(false);
+  const { token } = useAuth();
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    
-    if (!passcode.trim()) {
-      setError('合言葉を入力してください');
-      return;
-    }
-    
-    if (passcode.length < 3 || passcode.length > 20) {
-      setError('合言葉は3文字以上20文字以下で入力してください');
-      return;
-    }
-    
+  const handleCreate = async () => {
+    if (!token) { setError('ログインが必要です'); return; }
+    setIsCreating(true);
     setError('');
-    onPasscodeSubmit(passcode.trim());
+    try {
+      const res = await apiRequest('/api/game/room/create', {
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ deck_id: 'guest' }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        onRoomReady(data.passcode, true);
+      } else {
+        setError(data.error || 'ルームの作成に失敗しました');
+      }
+    } catch {
+      setError('ルームの作成に失敗しました');
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleJoin = async () => {
+    const code = joinCode.trim().toUpperCase();
+    if (code.length !== 6) {
+      setError('6文字のルームコードを入力してください');
+      return;
+    }
+    if (!token) { setError('ログインが必要です'); return; }
+    setIsJoining(true);
+    setError('');
+    try {
+      const res = await apiRequest(`/api/game/room/passcode/${code}/join`, {
+        method: 'POST',
+        credentials: 'include',
+        body: JSON.stringify({ deck_id: 'guest' }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        onRoomReady(code, false);
+      } else {
+        setError(data.error || 'ルームが見つかりません');
+      }
+    } catch {
+      setError('ルームへの参加に失敗しました');
+    } finally {
+      setIsJoining(false);
+    }
   };
 
   return (
     <div className="passcode-entry">
       <div className="passcode-card">
         <div className="passcode-header">
-          <h2>🎯 合言葉でマッチング</h2>
-          <p>同じ合言葉を入力した相手と対戦します</p>
+          <h2>🎯 対戦ルーム</h2>
+          <p>ルームを作成するか、コードを入力して参加します</p>
         </div>
-        
-        <form onSubmit={handleSubmit} className="passcode-form">
-          <div className="input-group">
-            <label htmlFor="passcode">合言葉</label>
-            <input
-              id="passcode"
-              type="text"
-              value={passcode}
-              onChange={(e) => setPasscode(e.target.value)}
-              placeholder="3文字以上20文字以下で入力"
-              maxLength={20}
-              minLength={3}
-              className={error ? 'error' : ''}
-            />
-            {error && <span className="error-message">{error}</span>}
-          </div>
-          
-          <button type="submit" className="enter-button">
-            🚀 入室する
+
+        {error && <div className="error-message" style={{ color: '#ff6b6b', marginBottom: '12px' }}>{error}</div>}
+
+        {/* ルーム作成 */}
+        <div style={{ marginBottom: '32px', textAlign: 'center' }}>
+          <button
+            onClick={handleCreate}
+            disabled={isCreating}
+            className="enter-button"
+            style={{ width: '100%', fontSize: '18px', padding: '16px' }}
+          >
+            {isCreating ? '作成中...' : '🏠 部屋を作る'}
           </button>
-        </form>
-        
-        <div className="instructions">
-          <h3>📋 遊び方</h3>
-          <ul>
-            <li>・合言葉を決めて「入室する」をクリック</li>
-            <li>・同じ合言葉の相手が来るまで待機</li>
-            <li>・2人揃ったら自動でゲーム開始！</li>
-          </ul>
-          
+          <p style={{ marginTop: '8px', fontSize: '13px', color: '#aaa' }}>
+            ルームコードが発行されます。相手に伝えてください。
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', margin: '16px 0' }}>
+          <hr style={{ flex: 1, borderColor: '#444' }} />
+          <span style={{ margin: '0 12px', color: '#888', fontSize: '14px' }}>または</span>
+          <hr style={{ flex: 1, borderColor: '#444' }} />
+        </div>
+
+        {/* ルーム参加 */}
+        <div>
+          <label style={{ display: 'block', marginBottom: '8px', fontWeight: 'bold' }}>
+            部屋に参加する
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <input
+              type="text"
+              value={joinCode}
+              onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+              placeholder="6文字のコード"
+              maxLength={6}
+              style={{
+                flex: 1,
+                padding: '12px',
+                fontSize: '18px',
+                letterSpacing: '4px',
+                textAlign: 'center',
+                textTransform: 'uppercase',
+                background: '#1a1a2e',
+                border: '2px solid #444',
+                borderRadius: '8px',
+                color: '#fff',
+              }}
+              onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+            />
+            <button
+              onClick={handleJoin}
+              disabled={isJoining}
+              className="enter-button"
+              style={{ padding: '12px 20px', whiteSpace: 'nowrap' }}
+            >
+              {isJoining ? '参加中...' : '参加する'}
+            </button>
+          </div>
+        </div>
+
+        <div className="instructions" style={{ marginTop: '32px' }}>
           <h3>🎮 操作方法</h3>
           <ul>
             <li>・←→: 左右移動</li>
@@ -73,17 +144,7 @@ export default function PasscodeEntry({ onPasscodeSubmit }: PasscodeEntryProps) 
             <li>・C: ホールド</li>
           </ul>
         </div>
-        
-        <div className="passcode-examples">
-          <h4>💡 合言葉の例</h4>
-          <div className="example-tags">
-            <span className="example-tag" onClick={() => setPasscode('テトリス')}>テトリス</span>
-            <span className="example-tag" onClick={() => setPasscode('対戦')}>対戦</span>
-            <span className="example-tag" onClick={() => setPasscode('友達')}>友達</span>
-            <span className="example-tag" onClick={() => setPasscode('github')}>github</span>
-          </div>
-        </div>
       </div>
     </div>
   );
-} 
+}

--- a/src/app/tetris/components/WaitingRoom.tsx
+++ b/src/app/tetris/components/WaitingRoom.tsx
@@ -7,6 +7,8 @@ import { apiRequest } from '@/lib/api';
 
 interface WaitingRoomProps {
   passcode: string;
+  isHost?: boolean;
+  alreadyJoined?: boolean;
   gameSession: GameSession | null;
   connectionStatus: 'disconnected' | 'connecting' | 'connected';
   onGameStart: () => void;
@@ -19,6 +21,8 @@ interface WaitingRoomProps {
 
 export default function WaitingRoom({
   passcode,
+  isHost = false,
+  alreadyJoined = false,
   gameSession,
   connectionStatus,
   onGameStart,
@@ -32,13 +36,14 @@ export default function WaitingRoom({
   const [testUserId, setTestUserId] = useState<string>('test-user-001');
   const [isPolling, setIsPolling] = useState(false);
   const [pollIntervalId, setPollIntervalId] = useState<NodeJS.Timeout | null>(null);
+  const [countdown, setCountdown] = useState<number | null>(null);
 
   // ユーザー名を取得するフック
   const { token } = useAuth();
   const { displayName: player1Name } = useUserDisplayName(gameSession?.player1?.user_id || null);
   const { displayName: player2Name } = useUserDisplayName(gameSession?.player2?.user_id || null);
 
-  const [hasJoined, setHasJoined] = useState<boolean>(false); // 重複実行防止フラグ
+  const [hasJoined, setHasJoined] = useState<boolean>(alreadyJoined); // 重複実行防止フラグ
   const [isInitialized, setIsInitialized] = useState<boolean>(false); // 初期化完了フラグ
   const joinInProgress = useRef<boolean>(false); // ref による排他制御
   const [wsConnecting, setWsConnecting] = useState(false);
@@ -109,6 +114,32 @@ export default function WaitingRoom({
       stopPolling();
     };
   }, [stopPolling]);
+
+  // 2人揃ったら5秒カウントダウン開始
+  useEffect(() => {
+    const playerCount = getPlayerCount();
+    if (playerCount === 2 && gameSession?.status === 'waiting' && connectionStatus === 'disconnected' && !wsConnecting) {
+      if (countdown === null) {
+        setCountdown(5);
+      }
+    } else if (playerCount < 2) {
+      setCountdown(null);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameSession?.player1, gameSession?.player2, gameSession?.status, connectionStatus, wsConnecting]);
+
+  // カウントダウンタイマー
+  useEffect(() => {
+    if (countdown === null) return;
+    if (countdown <= 0) {
+      setCountdown(null);
+      connectWebSocket();
+      return;
+    }
+    const timer = setTimeout(() => setCountdown(prev => prev !== null ? prev - 1 : null), 1000);
+    return () => clearTimeout(timer);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [countdown]);
 
   // 認証情報をサーバー経由で取得（httpOnly cookie を利用）
   useEffect(() => {
@@ -234,6 +265,13 @@ export default function WaitingRoom({
     }
   };
 
+  // alreadyJoined=true の場合はjoin済みなのでポーリングだけ開始
+  useEffect(() => {
+    if (!isInitialized || !alreadyJoined) return;
+    setTimeout(() => { startPolling(); }, 500);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isInitialized]);
+
   // 初期化完了且つまだ入室していない場合のみ実行
   useEffect(() => {
     if (!isInitialized || hasJoined) {
@@ -320,7 +358,14 @@ export default function WaitingRoom({
       <div className="waiting-card">
         <div className="waiting-header">
           <h2>ルーム待機中</h2>
-          <p><strong>合言葉:</strong> {passcode}</p>
+          {isHost && (
+            <div style={{ margin: '16px 0', padding: '16px', background: '#1a1a2e', borderRadius: '12px', border: '2px solid #4CAF50' }}>
+              <p style={{ margin: '0 0 8px', fontSize: '13px', color: '#aaa' }}>相手にこのコードを伝えてください</p>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <span style={{ fontSize: '32px', fontWeight: 'bold', letterSpacing: '6px', color: '#4CAF50' }}>{passcode}</span>
+              </div>
+            </div>
+          )}
           <p><strong>接続状態:</strong> {getConnectionStatusDisplay()}</p>
         </div>
 
@@ -392,27 +437,6 @@ export default function WaitingRoom({
 
         {getPlayerCount() === 2 && gameSession?.status === 'waiting' && (
           <div className="connection-controls" style={{ marginTop: '20px', textAlign: 'center' }}>
-            {connectionStatus === 'disconnected' && (
-              <button 
-                onClick={() => {
-                  connectWebSocket();
-                }} 
-                style={{ 
-                  backgroundColor: '#4CAF50', 
-                  color: 'white', 
-                  padding: '15px 30px', 
-                  border: 'none', 
-                  borderRadius: '8px',
-                  cursor: 'pointer',
-                  fontSize: '18px',
-                  fontWeight: 'bold',
-                  boxShadow: '0 4px 8px rgba(0,0,0,0.2)'
-                }}
-              >
-                準備完了
-              </button>
-            )}
-            
             {connectionStatus === 'connecting' && (
               <div style={{ padding: '15px 30px' }}>
                 <div style={{ color: '#ffaa00', fontSize: '18px', fontWeight: 'bold' }}>
@@ -420,13 +444,9 @@ export default function WaitingRoom({
                 </div>
               </div>
             )}
-            
             {connectionStatus === 'connected' && (
               <div style={{ padding: '15px 30px' }}>
                 <div style={{ color: '#4CAF50', fontSize: '18px', fontWeight: 'bold' }}>
-                  準備完了
-                </div>
-                <div style={{ fontSize: '14px', color: '#ccc', marginTop: '5px' }}>
                   ゲーム開始をお待ちください
                 </div>
               </div>

--- a/src/app/tetris/page.tsx
+++ b/src/app/tetris/page.tsx
@@ -54,14 +54,16 @@ type GamePhase = 'passcode_entry' | 'waiting' | 'playing' | 'game_over';
 export default function TetrisGame() {
   const [gamePhase, setGamePhase] = useState<GamePhase>('passcode_entry');
   const [passcode, setPasscode] = useState<string>('');
+  const [isHost, setIsHost] = useState<boolean>(false);
   const [gameSession, setGameSession] = useState<GameSession | null>(null);
   const [socket, setSocket] = useState<WebSocket | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<'disconnected' | 'connecting' | 'connected'>('disconnected');
   const [gameResult, setGameResult] = useState<GameResult | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
-  const handlePasscodeSubmit = (inputPasscode: string) => {
+  const handleRoomReady = (inputPasscode: string, host: boolean) => {
     setPasscode(inputPasscode);
+    setIsHost(host);
     setGamePhase('waiting');
   };
 
@@ -77,6 +79,7 @@ export default function TetrisGame() {
   const handleReturnToEntry = () => {
     setGamePhase('passcode_entry');
     setPasscode('');
+    setIsHost(false);
     setGameSession(null);
     setSocket(null);
     setConnectionStatus('disconnected');
@@ -98,14 +101,16 @@ export default function TetrisGame() {
       case 'passcode_entry':
         return (
           <PasscodeEntry
-            onPasscodeSubmit={handlePasscodeSubmit}
+            onRoomReady={handleRoomReady}
           />
         );
-      
+
       case 'waiting':
         return (
           <WaitingRoom
             passcode={passcode}
+            isHost={isHost}
+            alreadyJoined={true}
             gameSession={gameSession}
             connectionStatus={connectionStatus}
             onGameStart={handleGameStart}


### PR DESCRIPTION
## 概要
待機室周りのUXを改善

## 変更内容

`PasscodeEntry.tsx`
- 合言葉の自由入力フォームを廃止し、ルーム作成 / ルーム参加 の2アクションUIに変更
- 「部屋を作る」ボタン押下時に POST /api/game/room/create を呼びルームコードを発行
- 参加側は6文字のルームコードを入力して POST /api/game/room/passcode/{code}/join で参加
- Props: onPasscodeSubmit → onRoomReady(passcode, isHost) に変更

`WaitingRoom.tsx`
- isHost / alreadyJoined props を追加
- ホスト側は待機画面でルームコードを大きく表示（相手へのシェア用）
- 2人揃った際の「準備完了」ボタンを廃止し、5秒カウントダウン後に自動でWebSocket接続するよう変更
- alreadyJoined=true の場合はjoin処理をスキップしポーリングのみ開始（入室APIの二重呼び出し防止）

`page.tsx`
- isHost stateを追加
- handlePasscodeSubmit → handleRoomReady にリネームし isHost を管理
- WaitingRoomに isHost と alreadyJoined={true} を渡すよう修正

## 動作フロー

[PasscodeEntry]
  ├─ 「部屋を作る」→ API でルーム作成 → WaitingRoom(isHost=true)
  └─ コード入力 → API で参加 → WaitingRoom(isHost=false)

[WaitingRoom]
  └─ 2人揃ったら5秒後に自動でWS接続 → ゲーム開始